### PR TITLE
Don't use absolute path for library, instead use ldconfig to find it

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,7 +27,7 @@
         }],
         ['OS == "linux"', {
           'libraries': [
-            '/usr/local/lib/libcsound64.so'
+            '-lcsound64'
           ]
         }],
         ['OS == "win"', {


### PR DESCRIPTION
The csound library may not be located in /usr/local/lib (in my case it was in /usr/lib), but bindings.gyp gives an absolute path. 

By using the -l compiler flag we can just get g++ to find it automatically, instead of having to either manually edit the bindings or create a symlink.

There may be a similar approach for macOS, but I'm not sure if this is an issue there.