### PR TITLE
Fix the warnings while building from source

### DIFF
--- a/src/csound-api.cc
+++ b/src/csound-api.cc
@@ -141,7 +141,16 @@ struct CsoundGraphCallbackArguments {
   }
 
   void getArgv(v8::Local<v8::Value> *argv) const {
-    v8::Local<v8::Object> proxy = Nan::New(WINDATProxyConstructor)->NewInstance();
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(WINDATProxyConstructor);
+    Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+    v8::Local<v8::Object> proxy;
+
+    if(maybeProxy.IsEmpty()) {
+      Nan::ThrowError("Could not create new WINDATProxy instance");
+      return;
+    } else {
+      proxy = maybeProxy.ToLocalChecked();
+    }
     WINDATWrapper *wrapper = WINDATWrapper::Unwrap<WINDATWrapper>(proxy);
     wrapper->data = data;
     wrapper->fdataCopy = fdata;
@@ -292,7 +301,16 @@ struct CsoundInitializationOption {
 };
 
 static NAN_METHOD(Create) {
-  v8::Local<v8::Object> proxy = Nan::New(CSOUNDProxyConstructor)->NewInstance();
+  v8::Local<v8::Function> cons = Nan::New<v8::Function>(CSOUNDProxyConstructor);
+  Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+  v8::Local<v8::Object> proxy;
+
+  if(maybeProxy.IsEmpty()) {
+    Nan::ThrowError("Could not create new CSOUNDProxy instance");
+    return;
+  } else {
+    proxy = maybeProxy.ToLocalChecked();
+  }
   CSOUNDWrapper *wrapper = Nan::ObjectWrap::Unwrap<CSOUNDWrapper>(proxy);
   CSOUND *Csound = csoundCreate(wrapper);
   if (Csound) {
@@ -342,7 +360,16 @@ struct ORCTOKENWrapper : public Nan::ObjectWrap {
   static NAN_GETTER(next) {
     ORCTOKEN *token = tokenFromPropertyCallbackInfo(info)->next;
     if (token) {
-      v8::Local<v8::Object> proxy = Nan::New(ORCTOKENProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(ORCTOKENProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new ORCTOKENProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<ORCTOKENWrapper>(proxy)->token = token;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -367,7 +394,16 @@ struct TREEWrapper : public Nan::ObjectWrap {
   static NAN_GETTER(value) {
     ORCTOKEN *token = treeFromPropertyCallbackInfo(info)->value;
     if (token) {
-      v8::Local<v8::Object> proxy = Nan::New(ORCTOKENProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(ORCTOKENProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new ORCTOKENProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<ORCTOKENWrapper>(proxy)->token = token;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -382,7 +418,16 @@ struct TREEWrapper : public Nan::ObjectWrap {
 
   static void setPropertyCallbackInfoReturnValueWithTree(Nan::NAN_GETTER_ARGS_TYPE info, TREE *tree) {
     if (tree) {
-      v8::Local<v8::Object> proxy = Nan::New(TREEProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(TREEProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new TREEProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<TREEWrapper>(proxy)->tree = tree;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -397,7 +442,16 @@ struct TREEWrapper : public Nan::ObjectWrap {
 static NAN_METHOD(ParseOrc) {
   TREE *tree = csoundParseOrc(CsoundFromFunctionCallbackInfo(info), *Nan::Utf8String(info[1]));
   if (tree) {
-    v8::Local<v8::Object> proxy = Nan::New(TREEProxyConstructor)->NewInstance();
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(TREEProxyConstructor);
+    Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+    v8::Local<v8::Object> proxy;
+
+    if(maybeProxy.IsEmpty()) {
+      Nan::ThrowError("Could not create new TREEProxy instance");
+      return;
+    } else {
+      proxy = maybeProxy.ToLocalChecked();
+    }
     Nan::ObjectWrap::Unwrap<TREEWrapper>(proxy)->tree = tree;
     info.GetReturnValue().Set(proxy);
   } else {
@@ -949,12 +1003,30 @@ static void performCsoundListCreationFunction(Nan::NAN_METHOD_ARGS_TYPE info, in
   ItemType *list = NULL;
   int length = listCreationFunction(CsoundFromFunctionCallbackInfo(info), &list);
   if (list && length >= 0) {
-    v8::Local<v8::Object> listProxy = Nan::New(*ListProxyConstructorRef)->NewInstance();
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(*ListProxyConstructorRef);
+    Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+    v8::Local<v8::Object> listProxy;
+
+    if(maybeProxy.IsEmpty()) {
+      Nan::ThrowError("Could not create new ListProxy instance");
+      return;
+    } else {
+      listProxy = maybeProxy.ToLocalChecked();
+    }
     listProxy->SetAlignedPointerInInternalField(0, list);
     v8::Local<v8::Array> array = info[1].As<v8::Array>();
     Nan::SetPrivate(array, Nan::New("Csound::listProxy").ToLocalChecked(), listProxy);
     for (int i = 0; i < length; i++) {
-      v8::Local<v8::Object> itemProxy = Nan::New(*ItemProxyConstructorRef)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(*ItemProxyConstructorRef);
+      maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> itemProxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new ItemProxy instance");
+        return;
+      } else {
+        itemProxy = maybeProxy.ToLocalChecked();
+      }
       Nan::ObjectWrap::Unwrap<WrapperType>(itemProxy)->setItem(list[i]);
       array->Set(i, itemProxy);
     }
@@ -1036,7 +1108,17 @@ static NAN_METHOD(GetControlChannelHints) {
 }
 
 static NAN_METHOD(SetControlChannelHints) {
-  controlChannelHints_t hints = {};
+  controlChannelHints_t hints = {
+    .behav      = CSOUND_CONTROL_CHANNEL_NO_HINTS,
+    .dflt       = 0.0,
+    .min        = 0,
+    .max        = 0,
+    .x          = 0,
+    .y          = 0,
+    .width      = 0,
+    .height     = 0,
+    .attributes = NULL
+  };
   v8::Local<v8::Value> value = info[2];
   if (value->IsObject()) {
     v8::Local<v8::Object> object = value.As<v8::Object>();
@@ -1170,7 +1252,16 @@ static Nan::Persistent<v8::Function> UtilityNameListProxyConstructor;
 static NAN_METHOD(ListUtilities) {
   char **list = csoundListUtilities(CsoundFromFunctionCallbackInfo(info));
   if (list) {
-    v8::Local<v8::Object> listProxy = Nan::New(UtilityNameListProxyConstructor)->NewInstance();
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(UtilityNameListProxyConstructor);
+    Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+    v8::Local<v8::Object> listProxy;
+
+    if(maybeProxy.IsEmpty()) {
+      Nan::ThrowError("Could not create new UtilityNameListProxy instance");
+      return;
+    } else {
+      listProxy = maybeProxy.ToLocalChecked();
+    }
     listProxy->SetAlignedPointerInInternalField(0, list);
     v8::Local<v8::Array> array = Nan::New<v8::Array>();
     Nan::SetPrivate(array, Nan::New("Csound::listProxy").ToLocalChecked(), listProxy);
@@ -1245,7 +1336,16 @@ struct DebuggerInstrumentWrapper : public Nan::ObjectWrap {
   static NAN_GETTER(next) {
     debug_instr_t *next = instrumentFromPropertyCallbackInfo(info)->next;
     if (next) {
-      v8::Local<v8::Object> proxy = Nan::New(DebuggerInstrumentProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerInstrumentProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new DebuggerInstrumentProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<DebuggerInstrumentWrapper>(proxy)->instrument = next;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -1272,7 +1372,16 @@ struct DebuggerOpcodeWrapper : public Nan::ObjectWrap {
 
   static void setReturnValueWithDebuggerOpcode(Nan::ReturnValue<v8::Value> returnValue, debug_opcode_t *opcode) {
     if (opcode) {
-      v8::Local<v8::Object> proxy = Nan::New(DebuggerOpcodeProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerOpcodeProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new DebuggerOpcodeProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<DebuggerOpcodeWrapper>(proxy)->opcode = opcode;
       returnValue.Set(proxy);
     } else {
@@ -1311,7 +1420,16 @@ struct DebuggerVariableWrapper : public Nan::ObjectWrap {
   static NAN_GETTER(next) {
     debug_variable_t *next = variableFromPropertyCallbackInfo(info)->next;
     if (next) {
-      v8::Local<v8::Object> proxy = Nan::New(DebuggerVariableProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerVariableProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new DebuggerVariableProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<DebuggerVariableWrapper>(proxy)->variable = next;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -1335,7 +1453,16 @@ struct DebuggerBreakpointInfoWrapper : public Nan::ObjectWrap {
 
   static void setReturnValueWithDebuggerInstrument(Nan::ReturnValue<v8::Value> returnValue, debug_instr_t *instrument) {
     if (instrument) {
-      v8::Local<v8::Object> proxy = Nan::New(DebuggerInstrumentProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerInstrumentProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new DebuggerInstrumentProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<DebuggerInstrumentWrapper>(proxy)->instrument = instrument;
       returnValue.Set(proxy);
     } else {
@@ -1350,7 +1477,16 @@ struct DebuggerBreakpointInfoWrapper : public Nan::ObjectWrap {
   static NAN_GETTER(instrVarList) {
     debug_variable_t *instrVarList = breakpointInfoFromPropertyCallbackInfo(info)->instrVarList;
     if (instrVarList) {
-      v8::Local<v8::Object> proxy = Nan::New(DebuggerVariableProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerVariableProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new DebuggerVariableProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<DebuggerVariableWrapper>(proxy)->variable = instrVarList;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -1365,7 +1501,16 @@ struct DebuggerBreakpointInfoWrapper : public Nan::ObjectWrap {
   static NAN_GETTER(currentOpcode) {
     debug_opcode_t *opcode = breakpointInfoFromPropertyCallbackInfo(info)->currentOpcode;
     if (opcode) {
-      v8::Local<v8::Object> proxy = Nan::New(DebuggerOpcodeProxyConstructor)->NewInstance();
+      v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerOpcodeProxyConstructor);
+      Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+      v8::Local<v8::Object> proxy;
+
+      if(maybeProxy.IsEmpty()) {
+        Nan::ThrowError("Could not create new DebuggerOpcodeProxy instance");
+        return;
+      } else {
+        proxy = maybeProxy.ToLocalChecked();
+      }
       Unwrap<DebuggerOpcodeWrapper>(proxy)->opcode = opcode;
       info.GetReturnValue().Set(proxy);
     } else {
@@ -1377,7 +1522,16 @@ struct DebuggerBreakpointInfoWrapper : public Nan::ObjectWrap {
 static void CsoundBreakpointCallback(CSOUND *Csound, debug_bkpt_info_t *breakpointInfo, void *userData) {
   const int argc = 1;
   v8::Local<v8::Value> argv[argc];
-  v8::Local<v8::Object> proxy = Nan::New(DebuggerBreakpointInfoProxyConstructor)->NewInstance();
+  v8::Local<v8::Function> cons = Nan::New<v8::Function>(DebuggerBreakpointInfoProxyConstructor);
+  Nan::MaybeLocal<v8::Object> maybeProxy = Nan::NewInstance(cons);
+  v8::Local<v8::Object> proxy;
+
+  if(maybeProxy.IsEmpty()) {
+    Nan::ThrowError("Could not create new DebuggerBreakpointInfoProxy instance");
+    return;
+  } else {
+    proxy = maybeProxy.ToLocalChecked();
+  }
   DebuggerBreakpointInfoWrapper::Unwrap<DebuggerBreakpointInfoWrapper>(proxy)->breakpointInfo = breakpointInfo;
   argv[0] = proxy;
   ((CSOUNDWrapper *)csoundGetHostData(Csound))->CsoundBreakpointCallbackObject->Call(argc, argv);


### PR DESCRIPTION
There are two changes here, the update to the NAN calls to use the 'maybe type', and explicitly setting the hints struct (even though {} zeroes it, g++ still complains, the alternative is to pass a compiler flag to suppress the warning).

I must admit I don't fully understand the NAN changes, and would appreciate some testing on other platforms (although the CI scripts will at least check the build part)