### PR TITLE
Fixed linking issue

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,7 +27,7 @@
         }],
         ['OS == "linux"', {
           'libraries': [
-            '-lcsound64'
+            '-lcsound'
           ]
         }],
         ['OS == "win"', {


### PR DESCRIPTION
Not sure if this is linker-specific or not but for gcc 10.2.0 using GNU ld 2.35.1 on my system (Gentoo Linux), `-lcsound64`is not a valid linker flag. The correct flag seems to be `-lcsound`. Using the Csound C API, I was able to successfully call the Csound library in a C program by supplying the linker flag `-lcsound` but `-lcsound64` gives a linker error.

By changing `-lcsound64` to `-lcsound` in `binding.gyp` and installing it manually with npm, the issue is resolved and the module seems to work. Is the library name `csound64` on other distros?